### PR TITLE
Fixes build script

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,6 +10,27 @@
   "dependencies": [
     "boost-container"
   ],
+  "vcpkg-configuration": {
+    "default-registry": {
+      "kind": "git",
+      "repository": "https://github.com/Microsoft/vcpkg",
+      "baseline": "fc6345e114c2e2c4f9714037340ccb08326b3e8c"
+    },
+    "registries": [
+      {
+        "kind": "git",
+        "repository": "https://github.com/microsoft/vcpkg",
+        "baseline": "7ef729383ab801504035a4445b6dbca18c8865c8",
+        "packages": [ "boost-modular-build-helper" ]
+      },
+      {
+        "kind": "git",
+        "repository": "https://github.com/microsoft/vcpkg",
+        "baseline": "caa7579a1c48e2ca770f6ccf98cb03db95642631",
+        "packages": [ "boost*", "boost-*" ]
+      }
+    ]
+  },
   "features": {
     "standalone": {
       "description": "Build as a standalone program",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -43,6 +43,5 @@
       ]
     }
   },
-  "default-features": ["standalone"],
-  "builtin-baseline": "4cb4a5c5ddcb9de0c83c85837ee6974c8333f032"
+  "default-features": ["standalone"]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -14,7 +14,7 @@
     "default-registry": {
       "kind": "git",
       "repository": "https://github.com/Microsoft/vcpkg",
-      "baseline": "fc6345e114c2e2c4f9714037340ccb08326b3e8c"
+      "baseline": "4cb4a5c5ddcb9de0c83c85837ee6974c8333f032"
     },
     "registries": [
       {


### PR DESCRIPTION
Uses the fix outlined [here](https://github.com/microsoft/vcpkg/issues/38980#issuecomment-2138632860) to bring `boost-modular-build-helper` up by half a version and stop CMake from failing.

Tested the build action on my own repo and it builds with no discernible problems.