### PR TITLE
Pacify PPJ teething problems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
   PROJECT_NAME: Caprica
-  CMAKE_ARGS: "-DCHAMPOLLION_USE_STATIC_RUNTIME:BOOL=TRUE -DENABLE_STATIC_RUNTIME:BOOL=TRUE -DCMAKE_INSTALL_PREFIX:STRING=build/extern -DVCPKG_TARGET_TRIPLET:STRING=x64-windows-static -DCMAKE_TOOLCHAIN_FILE:STRING=C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
   
 jobs:
   build:
@@ -23,32 +22,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    
-    - name: Setup vcpkg
-      working-directory: c:/
-      run: |
-        git clone https://github.com/microsoft/vcpkg.git
-        cd vcpkg
-        bootstrap-vcpkg.bat
-        vcpkg.exe integrate install
+    - uses: lukka/get-cmake@latest
 
-    - name: Cache vcpkg packages
-      uses: actions/cache@v3
+    - name: Setup vcpkg (without building packages)
+      uses: lukka/run-vcpkg@v11
+
+    - name: Run CMake in accordance with CMakePreset.json and run vcpkg
+      uses: lukka/run-cmake@v10
       with:
-        path: ${{github.workspace}}/build/vcpkg_installed
-        key: ${{ runner.os }}-vcpkg-${{ hashFiles('${{github.workspace}}/vcpkg.json') }}
-        restore-keys: |
-          ${{ runner.os }}-vcpkg-${{ hashFiles('${{github.workspace}}/vcpkg.json') }}
-          ${{ runner.os }}-vcpkg-
-
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCAPRICA_USE_STATIC_RUNTIME:BOOL=TRUE -DENABLE_STATIC_RUNTIME:BOOL=TRUE -DCMAKE_INSTALL_PREFIX:STRING=build/extern -DVCPKG_TARGET_TRIPLET:STRING=x64-windows-static -DCMAKE_TOOLCHAIN_FILE:STRING=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
-
-    - name: Build
-      # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+        buildPreset: "release-msvc"
+        buildPresetAdditionalArgs: "['--config Release']"
   
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v3.1.2
@@ -56,7 +39,7 @@ jobs:
         # Artifact name
         name: ${{ env.PROJECT_NAME }}
         # A file, directory or wildcard pattern that describes what to upload
-        path: build/Caprica/Release/Caprica.exe
+        path: build/extern/Caprica/Caprica.exe
         # The desired behavior if no files are found using the provided path.
         retention-days: 90
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,7 @@ jobs:
     - name: Run CMake in accordance with CMakePreset.json and run vcpkg
       uses: lukka/run-cmake@v10
       with:
-        cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
         configurePreset: build-release-msvc
-        configurePresetAdditionalArgs: "['-DCMAKE_TOOLCHAIN_FILE:STRING=C:/vcpkg/scripts/buildsystems/vcpkg.cmake']"
         buildPreset: release-msvc
   
     - name: Upload a Build Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         buildPreset: release-msvc
   
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: ${{ env.PROJECT_NAME }}
@@ -52,7 +52,7 @@ jobs:
     needs: build
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.PROJECT_NAME }}
           path: artifacts/${{ env.PROJECT_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,9 @@ jobs:
     - name: Run CMake in accordance with CMakePreset.json and run vcpkg
       uses: lukka/run-cmake@v10
       with:
-        buildPreset: "release-msvc"
-        buildPresetAdditionalArgs: "['--config Release']"
+        cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
+        configurePreset: release-msvc
+        configurePresetAdditionalArgs: "['-DCMAKE_TOOLCHAIN_FILE:STRING=C:/vcpkg/scripts/buildsystems/vcpkg.cmake']"
   
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,9 @@ jobs:
       uses: lukka/run-cmake@v10
       with:
         cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
-        configurePreset: release-msvc
+        configurePreset: build-release-msvc
         configurePresetAdditionalArgs: "['-DCMAKE_TOOLCHAIN_FILE:STRING=C:/vcpkg/scripts/buildsystems/vcpkg.cmake']"
+        buildPreset: release-msvc
   
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v3.1.2

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ Caprica/INSTALL.vcxproj.filters
 Caprica/cmake_install.cmake
 
 x64/
+/out/install/x64-Debug/bin
+/CMakeSettings.json

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -69,6 +69,24 @@
           "value": "RelWithDebInfo"
         }
       }
+    },
+    {
+      "name": "build-debug-msvc",
+      "inherits": [
+        "base",
+        "vcpkg",
+        "x64",
+        "msvc"
+      ],
+      "displayName": "Debug",
+      "description": "Debug build for testing.",
+      "binaryDir": "${sourceDir}/build/debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Debug"
+        }
+      }
     }
   ],
   "buildPresets": [
@@ -77,6 +95,12 @@
       "displayName": "Release (MSVC)",
       "configurePreset": "build-release-msvc",
       "description": "Optimized release Build."
+    },
+    {
+      "name": "debug-msvc",
+      "displayName": "Debug (MSVC)",
+      "configurePreset": "build-debug-msvc",
+      "description": "Debug build for local testing."
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,82 @@
+{
+  "version": 8,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "cacheVariables": {
+        "CAPRICA_USE_STATIC_RUNTIME": {
+          "type": "BOOL",
+          "value": "TRUE"
+        },
+        "ENABLE_STATIC_RUNTIME": {
+          "type": "BOOL",
+          "value": "TRUE"
+        },
+        "CMAKE_CXX_FLAGS": "$env{CPP_COMPILER}"
+      }
+    },
+    {
+      "name": "vcpkg",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_TARGET_TRIPLET": "x64-windows-static"
+      }
+    },
+    {
+      "name": "x64",
+      "hidden": true,
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      }
+    },
+    {
+      "name": "msvc",
+      "hidden": true,
+      "environment": {
+        "CPP_COMPILER": "/permissive- /Zc:preprocessor /EHsc $penv{CXXFLAGS}"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "intelliSenseMode": "windows-msvc-x64",
+          "enableMicrosoftCodeAnalysis": true,
+          "enableClangTidyCodeAnalysis": true
+        }
+      }
+    },
+    {
+      "name": "build-release-msvc",
+      "inherits": [
+        "base",
+        "vcpkg",
+        "x64",
+        "msvc"
+      ],
+      "displayName": "Release",
+      "description": "Optimized release Build.",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/extern",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "RelWithDebInfo"
+        }
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "release-msvc",
+      "displayName": "Release (MSVC)",
+      "configurePreset": "build-release-msvc",
+      "description": "Optimized release Build."
+    }
+  ]
+}

--- a/Caprica/common/CapricaInputFile.cpp
+++ b/Caprica/common/CapricaInputFile.cpp
@@ -140,7 +140,7 @@ PCompInputFile::PCompInputFile(const std::filesystem::path& _path,
                                bool isFolder,
                                const std::filesystem::path& _cwd)
     : IInputFile(_path, noRecurse, _cwd) {
-  isFolder = isFolder;
+  this->isFolder = isFolder;
 }
 
 bool PCompInputFile::resolve() {

--- a/Caprica/common/CapricaReportingContext.h
+++ b/Caprica/common/CapricaReportingContext.h
@@ -133,6 +133,13 @@ struct CapricaReportingContext final {
                     identifier_ref,
                     parentName)
 
+  // Not a base game warning, but some ubiquitous libraries fall prey to this.
+  DEFINE_WARNING_A1(1006, 
+                    Strict_Keyword_Identifiers, 
+                    "'{}' is a keyword (e.g. Int, Function) but is used as an identifier.",
+                    identifier_ref, 
+                    idName)
+
   // Warnings 2000-2199 are for engine imposed limitations.
 
   DEFINE_WARNING_A2(2001,

--- a/Caprica/main_options.cpp
+++ b/Caprica/main_options.cpp
@@ -206,6 +206,8 @@ bool parseCommandLineArguments(int argc, char* argv[], caprica::CapricaJobManage
         "Ensure values returned from BetaOnly and DebugOnly functions don't escape, as that will cause invalid code generation.")
       ("disable-implicit-conversion-from-none", po::bool_switch()->default_value(false),
         "Disable implicit conversion from None in most situations where the use of None likely wasn't the author's intention.")
+      ("disable-keywords-as-identifiers", po::bool_switch()->default_value(false),
+        "Disable the ability to use some keywords (e.g. Switch, Parent) as identifiers in select cases.")
       ("skyrim-allow-unknown-events-on-non-native-class", po::value<bool>(&conf::Skyrim::skyrimAllowUnknownEventsOnNonNativeClass)->default_value(true),
         "Allow unknown events to be defined on non-native classes. This is encountered with some scripts in the base game having Events that are not present on ObjectReference.");
 
@@ -560,6 +562,8 @@ bool parseCommandLineArguments(int argc, char* argv[], caprica::CapricaJobManage
       conf::Warnings::warningsToHandleAsErrors.insert(1002);
     } else if (vm["disable-implicit-conversion-from-none"].as<bool>()) {
       conf::Warnings::warningsToHandleAsErrors.insert(1003);
+    } else if (vm["disable-keywords-as-identifiers"].as<bool>()) {
+      conf::Warnings::warningsToHandleAsErrors.insert(1006);
     }
 
     if (vm.count("disable-warning")) {

--- a/Caprica/main_options.cpp
+++ b/Caprica/main_options.cpp
@@ -206,7 +206,7 @@ bool parseCommandLineArguments(int argc, char* argv[], caprica::CapricaJobManage
         "Ensure values returned from BetaOnly and DebugOnly functions don't escape, as that will cause invalid code generation.")
       ("disable-implicit-conversion-from-none", po::bool_switch()->default_value(false),
         "Disable implicit conversion from None in most situations where the use of None likely wasn't the author's intention.")
-      ("skyrim-allow-unknown-events-on-non-native-class", po::value<bool>(&conf::Skyrim::skyrimAllowUnknownEventsOnNonNativeClass)->default_value(false),
+      ("skyrim-allow-unknown-events-on-non-native-class", po::value<bool>(&conf::Skyrim::skyrimAllowUnknownEventsOnNonNativeClass)->default_value(true),
         "Allow unknown events to be defined on non-native classes. This is encountered with some scripts in the base game having Events that are not present on ObjectReference.");
 
     po::options_description skyrimCompatibilityDesc("Skyrim compatibility (default true with '--game=skyrim')");

--- a/Caprica/papyrus/PapyrusCompilationContext.cpp
+++ b/Caprica/papyrus/PapyrusCompilationContext.cpp
@@ -126,7 +126,8 @@ std::string_view findScriptName(const std::string_view& data, const std::string_
       next = data.size() - 1;
     auto line = data.substr(last, next - last);
     auto begin = line.find_first_not_of(" \t");
-    if (strnicmp(line.substr(begin, startstring.size()).data(), startstring.data(), startstring.size()) == 0) {
+    auto startSize = startstring.size();
+    if (line.size() > startSize && strnicmp(line.substr(begin, startSize).data(), startstring.data(), startSize) == 0) {
       auto first = line.find_first_not_of(" \t", startstring.size() + begin);
       return line.substr(first, line.find_first_of(" \t", first) - first);
     }

--- a/Caprica/papyrus/parser/PapyrusLexer.cpp
+++ b/Caprica/papyrus/parser/PapyrusLexer.cpp
@@ -236,6 +236,25 @@ static const caseless_unordered_identifier_ref_map<TokenType> languageExtensions
   { "to",         TokenType::kTo        },
 };
 
+// keywords which can never pass as identifiers
+static const std::unordered_set<TokenType> nonIdentifiersSet {
+  TokenType::kAuto, 
+  TokenType::kAutoReadOnly, 
+  TokenType::kBool, 
+  TokenType::kConst,
+  TokenType::kFalse, 
+  TokenType::kFloat, 
+  TokenType::kInt, 
+  TokenType::kNone, 
+  TokenType::kString, 
+  TokenType::kStruct, 
+  TokenType::kVar,
+};
+
+const bool keywordCanBeIdentifier(TokenType tp) {
+  return keywordIsInGame(tp, conf::Papyrus::game, true) && nonIdentifiersSet.find(tp) == nonIdentifiersSet.end();
+}
+
 ALWAYS_INLINE
 static bool isAsciiAlphaNumeric(int c) {
   return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');

--- a/Caprica/papyrus/parser/PapyrusLexer.h
+++ b/Caprica/papyrus/parser/PapyrusLexer.h
@@ -141,6 +141,7 @@ constexpr TokenType STARFIELD_MAX_KEYWORD = TokenType::kTryGuard;
 constexpr bool keywordIsLanguageExtension(TokenType tp) {
   return tp >= TokenType::kBreak && tp <= TokenType::kTo;
 }
+const bool keywordCanBeIdentifier(TokenType tp);
 constexpr bool keywordIsInGame(TokenType tp, GameID game, bool includeExtensions = false) {
   if (includeExtensions && keywordIsLanguageExtension(tp))
     return true;

--- a/Caprica/papyrus/parser/PapyrusParser.h
+++ b/Caprica/papyrus/parser/PapyrusParser.h
@@ -48,6 +48,7 @@ private:
 
   PapyrusType expectConsumePapyrusType();
   PapyrusValue expectConsumePapyrusValue();
+  identifier_ref expectConsumeKeywordOrIdentRef();
   PapyrusUserFlags maybeConsumeUserFlags(CapricaUserFlagsDefinition::ValidLocations location);
 
   ALWAYS_INLINE

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -16,6 +16,12 @@
       "repository": "https://github.com/microsoft/vcpkg",
       "baseline": "7ef729383ab801504035a4445b6dbca18c8865c8",
       "packages": [ "boost-modular-build-helper" ]
+    },
+    {
+      "kind": "git",
+      "repository": "https://github.com/microsoft/vcpkg",
+      "baseline": "4cb4a5c5ddcb9de0c83c85837ee6974c8333f032",
+      "packages": [ "fmt" ]
     }
   ]
 }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/Microsoft/vcpkg",
-    "baseline": "f14984af3738e69f197bf0e647a8dca12de92996"
+    "baseline": "3508985146f1b1d248c67ead13f8f54be5b4f5da"
   },
   "registries": [
     {

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,21 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "repository": "https://github.com/Microsoft/vcpkg",
+    "baseline": "4cb4a5c5ddcb9de0c83c85837ee6974c8333f032"
+  },
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://github.com/microsoft/vcpkg",
+      "baseline": "7ef729383ab801504035a4445b6dbca18c8865c8",
+      "packages": [ "boost-modular-build-helper" ]
+    },
+    {
+      "kind": "git",
+      "repository": "https://github.com/microsoft/vcpkg",
+      "baseline": "caa7579a1c48e2ca770f6ccf98cb03db95642631",
+      "packages": [ "boost*", "boost-*" ]
+    }
+  ]
+}

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/Microsoft/vcpkg",
-    "baseline": "4cb4a5c5ddcb9de0c83c85837ee6974c8333f032"
+    "baseline": "f14984af3738e69f197bf0e647a8dca12de92996"
   },
   "registries": [
     {

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,14 +8,14 @@
     {
       "kind": "git",
       "repository": "https://github.com/microsoft/vcpkg",
-      "baseline": "7ef729383ab801504035a4445b6dbca18c8865c8",
-      "packages": [ "boost-modular-build-helper" ]
+      "baseline": "caa7579a1c48e2ca770f6ccf98cb03db95642631",
+      "packages": [ "boost*", "boost-*" ]
     },
     {
       "kind": "git",
       "repository": "https://github.com/microsoft/vcpkg",
-      "baseline": "caa7579a1c48e2ca770f6ccf98cb03db95642631",
-      "packages": [ "boost*", "boost-*" ]
+      "baseline": "7ef729383ab801504035a4445b6dbca18c8865c8",
+      "packages": [ "boost-modular-build-helper" ]
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,27 +10,6 @@
   "dependencies": [
     "boost-container"
   ],
-  "vcpkg-configuration": {
-    "default-registry": {
-      "kind": "git",
-      "repository": "https://github.com/Microsoft/vcpkg",
-      "baseline": "4cb4a5c5ddcb9de0c83c85837ee6974c8333f032"
-    },
-    "registries": [
-      {
-        "kind": "git",
-        "repository": "https://github.com/microsoft/vcpkg",
-        "baseline": "7ef729383ab801504035a4445b6dbca18c8865c8",
-        "packages": [ "boost-modular-build-helper" ]
-      },
-      {
-        "kind": "git",
-        "repository": "https://github.com/microsoft/vcpkg",
-        "baseline": "caa7579a1c48e2ca770f6ccf98cb03db95642631",
-        "packages": [ "boost*", "boost-*" ]
-      }
-    ]
-  },
   "features": {
     "standalone": {
       "description": "Build as a standalone program",


### PR DESCRIPTION
I've encountered a couple of issues when trying to use PPJ files. This is an attempt to fix them.

So far, this PR:

- Fixes import directories being treated as files
- Fixes crash when source files have lines shorter than 9 chars before `scriptname` declaration
- Changes the default value of the `skyrim-allow-unknown-event...` option to align with the other Strict checks (i.e. disabled by default).
- Allows some keywords to be used as function parameters, with the proper strict check. Can be extended to do more.