### PR TITLE
Remove "native script" errors for Skyrim game

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
   
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: ${{ env.PROJECT_NAME }}
@@ -69,7 +69,7 @@ jobs:
     needs: build
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.PROJECT_NAME }}
           path: artifacts/${{ env.PROJECT_NAME }}

--- a/Caprica/common/CapricaConfig.cpp
+++ b/Caprica/common/CapricaConfig.cpp
@@ -64,7 +64,6 @@ GameID game { GameID::UNKNOWN };
 }
 
 namespace Skyrim {
-  bool skyrimAllowUnknownEventsOnNonNativeClass{ true };
   bool skyrimAllowObjectVariableShadowingParentProperty{ true };
   bool skyrimAllowLocalVariableShadowingParentProperty{ true };
   bool skyrimAllowLocalUseBeforeDeclaration{ true };

--- a/Caprica/common/CapricaConfig.h
+++ b/Caprica/common/CapricaConfig.h
@@ -120,8 +120,6 @@ namespace Papyrus {
 
 // Skyrim-specific settings to emulate the behavior of the Skyrim PCompiler
 namespace Skyrim {
-  // Allows non-inherited events to be declared on non-native classes
-  extern bool skyrimAllowUnknownEventsOnNonNativeClass;
   // Allows object variables to shadow parent class properties
   extern bool skyrimAllowObjectVariableShadowingParentProperty;
   // Allows local variables to shadow parent class properties

--- a/Caprica/common/CapricaReportingContext.h
+++ b/Caprica/common/CapricaReportingContext.h
@@ -275,7 +275,7 @@ struct CapricaReportingContext final {
 
   DEFINE_WARNING_A3(7000,
                     Skyrim_Unknown_Event_On_Non_Native_Class,
-                    "Unknown Event ('{}') on non-native class '{}' that extends from '{}'.",
+                    "Unknown Event ('{}') on class '{}' that extends from '{}'.",
                     identifier_ref,
                     eventName,
                     identifier_ref,

--- a/Caprica/main_options.cpp
+++ b/Caprica/main_options.cpp
@@ -206,13 +206,9 @@ bool parseCommandLineArguments(int argc, char* argv[], caprica::CapricaJobManage
         "Ensure values returned from BetaOnly and DebugOnly functions don't escape, as that will cause invalid code generation.")
       ("disable-implicit-conversion-from-none", po::bool_switch()->default_value(false),
         "Disable implicit conversion from None in most situations where the use of None likely wasn't the author's intention.")
-      ("skyrim-allow-unknown-events-on-non-native-class", po::value<bool>(&conf::Skyrim::skyrimAllowUnknownEventsOnNonNativeClass)->default_value(false),
-        "Allow unknown events to be defined on non-native classes. This is encountered with some scripts in the base game having Events that are not present on ObjectReference.");
 
     po::options_description skyrimCompatibilityDesc("Skyrim compatibility (default true with '--game=skyrim')");
     skyrimCompatibilityDesc.add_options()
-      ("allow-unknown-events", po::value<bool>(&conf::Skyrim::skyrimAllowUnknownEventsOnNonNativeClass)->default_value(true),
-        "Allow unknown events to be defined on non-native classes. This is encountered with some scripts in the base game having Events that are not present on ObjectReference.")
       ("allow-var-shadow-parent", po::value<bool>(&conf::Skyrim::skyrimAllowObjectVariableShadowingParentProperty)->default_value(true),
         "Allow Object variable names in derived classes to shadow properties in parent classes.")
       ("allow-local-shadow-parent", po::value<bool>(&conf::Skyrim::skyrimAllowLocalVariableShadowingParentProperty)->default_value(true),
@@ -508,7 +504,6 @@ bool parseCommandLineArguments(int argc, char* argv[], caprica::CapricaJobManage
 
     if (conf::Papyrus::game != GameID::Skyrim) {
       // turn off skyrim options
-      conf::Skyrim::skyrimAllowUnknownEventsOnNonNativeClass = false;
       conf::Skyrim::skyrimAllowObjectVariableShadowingParentProperty = false;
       conf::Skyrim::skyrimAllowLocalVariableShadowingParentProperty = false;
       conf::Skyrim::skyrimAllowLocalUseBeforeDeclaration = false;

--- a/Caprica/main_options.cpp
+++ b/Caprica/main_options.cpp
@@ -205,7 +205,7 @@ bool parseCommandLineArguments(int argc, char* argv[], caprica::CapricaJobManage
       ("ensure-betaonly-debugonly-dont-escape", po::bool_switch()->default_value(false),
         "Ensure values returned from BetaOnly and DebugOnly functions don't escape, as that will cause invalid code generation.")
       ("disable-implicit-conversion-from-none", po::bool_switch()->default_value(false),
-        "Disable implicit conversion from None in most situations where the use of None likely wasn't the author's intention.")
+        "Disable implicit conversion from None in most situations where the use of None likely wasn't the author's intention.");
 
     po::options_description skyrimCompatibilityDesc("Skyrim compatibility (default true with '--game=skyrim')");
     skyrimCompatibilityDesc.add_options()

--- a/Caprica/papyrus/PapyrusFunction.cpp
+++ b/Caprica/papyrus/PapyrusFunction.cpp
@@ -90,7 +90,7 @@ void PapyrusFunction::semantic(PapyrusResolutionContext* ctx) {
 void PapyrusFunction::semantic2(PapyrusResolutionContext* ctx) {
   if (isGlobal() && ctx->state && ctx->state->name != "")
     ctx->reportingContext.error(location, "Global functions are only allowed in the empty state.");
-  if (isNative() && !ctx->object->isNative())
+  if (conf::Papyrus::game != GameID::Skyrim && isNative() && !ctx->object->isNative())
     ctx->reportingContext.error(location, "You can only define Native functions in a script marked Native.");
 
   ctx->ensureNamesAreUnique(parameters, "parameter");

--- a/Caprica/papyrus/PapyrusState.cpp
+++ b/Caprica/papyrus/PapyrusState.cpp
@@ -53,7 +53,7 @@ void PapyrusState::semantic2(PapyrusResolutionContext* ctx) {
     for (auto f : functions) {
       auto baseFunc = searchRootStateForFunction(f.second->name, parentClass);
       if (f.second->functionType == PapyrusFunctionType::Event && !baseFunc && !ctx->object->isNative()) {
-        if (conf::Papyrus::game == GameID::Skyrim && conf::Skyrim::skyrimAllowUnknownEventsOnNonNativeClass) {
+        if (conf::Papyrus::game == GameID::Skyrim) {
           ctx->reportingContext.warning_W7000_Skyrim_Unknown_Event_On_Non_Native_Class(
               f.second->location,
               f.second->name,


### PR DESCRIPTION
I dont know when exactly "native scripts" became a thing or if it something Caprica specific (in which case, pardon this PR), but at least for Skyrim the "native" keyword exclusively belongs to function definitions, there is no such thing as a "native script"

These are a handful of changes to skip "native script" related checks for Skyrim only, in particular
- new event definitions only throw a warning, the CLI argument has been removed (as new event definitions are perfectly valid and a common praxis when using script extenders, including SKSE itself)
- native function definitions on "non native scripts" no longer throw an error, as all of Skyrim's scripts are "non native" and adding "native" to a script definition would throw an error by Bethesdas compiler

Additionally, I made a small change to the workflow which had a depreciated error before